### PR TITLE
Reduce allocation by targeting .net core 2.2

### DIFF
--- a/src/Prometheus.Client/Prometheus.Client.csproj
+++ b/src/Prometheus.Client/Prometheus.Client.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>.NET client for Prometheus</Description>
     <Copyright>2019 © Sergey Kuznetsov</Copyright>
     <AssemblyTitle>Prometheus.Client</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Sergey Kuznetsov</Authors>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netcoreapp2.2;</TargetFrameworks>
     <AssemblyName>Prometheus.Client</AssemblyName>
     <PackageId>Prometheus.Client</PackageId>
     <PackageTags>prometheus;metrics</PackageTags>
@@ -18,11 +18,15 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Diagnostics.Process">
-      <Version>4.3.0</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
+    <PackageReference Include="System.Diagnostics.Process" version="4.3.0" />
+    <PackageReference Include="System.Memory" version="4.5.2" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" version="4.5.2" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/tests/Prometheus.Client.Benchmarks/SerializationBenchmarks.cs
+++ b/tests/Prometheus.Client.Benchmarks/SerializationBenchmarks.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Prometheus.Client;
+using Prometheus.Client.Collectors;
+
+namespace Prometheus.Client.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class SerializationBenchmarks
+    {
+        // Metric -> Variant -> Label values
+        private static readonly string[][][] _labelValueRows;
+
+        private const int _metricCount = 100;
+        private const int _variantCount = 100;
+        private const int _labelCount = 5;
+
+        private const string _help = "arbitrary help message for metric, not relevant for benchmarking";
+
+        static SerializationBenchmarks()
+        {
+            _labelValueRows = new string[_metricCount][][];
+
+            for (var metricIndex = 0; metricIndex < _metricCount; metricIndex++)
+            {
+                var variants = new string[_variantCount][];
+                _labelValueRows[metricIndex] = variants;
+
+                for (var variantIndex = 0; variantIndex < _variantCount; variantIndex++)
+                {
+                    var values = new string[_labelCount];
+                    _labelValueRows[metricIndex][variantIndex] = values;
+
+                    for (var labelIndex = 0; labelIndex < _labelCount; labelIndex++)
+                        values[labelIndex] = $"metric{metricIndex:D2}_label{labelIndex:D2}_variant{variantIndex:D2}";
+                }
+            }
+        }
+
+        private readonly CollectorRegistry _registry = new CollectorRegistry();
+        private readonly Prometheus.Client.Counter[] _counters;
+        private readonly Prometheus.Client.Gauge[] _gauges;
+        private readonly Prometheus.Client.Summary[] _summaries;
+        private readonly Prometheus.Client.Histogram[] _histograms;
+
+        public SerializationBenchmarks()
+        {
+            _counters = new Prometheus.Client.Counter[_metricCount];
+            _gauges = new Prometheus.Client.Gauge[_metricCount];
+            _summaries = new Prometheus.Client.Summary[_metricCount];
+            _histograms = new Prometheus.Client.Histogram[_metricCount];
+
+            var factory = new MetricFactory(_registry);
+
+            // Just use 1st variant for the keys (all we care about are that there is some name-like value in there).
+            for (var metricIndex = 0; metricIndex < _metricCount; metricIndex++)
+            {
+                _counters[metricIndex] = factory.CreateCounter($"counter{metricIndex:D2}", _help, _labelValueRows[metricIndex][0]);
+                _gauges[metricIndex] = factory.CreateGauge($"gauge{metricIndex:D2}", _help, _labelValueRows[metricIndex][0]);
+                _summaries[metricIndex] = factory.CreateSummary($"summary{metricIndex:D2}", _help, _labelValueRows[metricIndex][0]);
+                _histograms[metricIndex] = factory.CreateHistogram($"histogram{metricIndex:D2}", _help, _labelValueRows[metricIndex][0]);
+            }
+        }
+
+        [GlobalSetup]
+        public void GenerateData()
+        {
+            for (var metricIndex = 0; metricIndex < _metricCount; metricIndex++)
+            {
+                for (var variantIndex = 0; variantIndex < _variantCount; variantIndex++)
+                {
+                    _counters[metricIndex].Labels(_labelValueRows[metricIndex][variantIndex]).Inc();
+                    _gauges[metricIndex].Labels(_labelValueRows[metricIndex][variantIndex]).Inc();
+                    _summaries[metricIndex].Labels(_labelValueRows[metricIndex][variantIndex]).Observe(variantIndex);
+                    _histograms[metricIndex].Labels(_labelValueRows[metricIndex][variantIndex]).Observe(variantIndex);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void CollectAndSerialize()
+        {
+            using (var stream = new NullStream())
+            {
+                ScrapeHandler.Process(_registry, stream);
+            }
+        }
+
+        /// <summary>
+        /// A stream that reads and writes nothing.
+        /// </summary>
+        internal sealed class NullStream : Stream
+        {
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => 0;
+
+            public override long Position { get; set; } = 0;
+
+            public override void Flush()
+            {
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                return 0;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                return 0;
+            }
+
+            public override void SetLength(long value)
+            {
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
New target added to netcore2.2 to use no-allocation TryFormat on double. This dramatically reduces allocation while scrapping on netcore2.2