### PR TITLE
Added metric configuration to suppress empty samples

### DIFF
--- a/src/Prometheus.Client/Collectors/Collector.cs
+++ b/src/Prometheus.Client/Collectors/Collector.cs
@@ -36,10 +36,14 @@ namespace Prometheus.Client.Collectors
         void ICollector.Collect(IMetricsWriter writer)
         {
             writer.WriteMetricHeader(Configuration.Name, Type, Configuration.Help);
-            Unlabelled.Collect(writer);
+            if(!Configuration.SuppressEmptySamples || Unlabelled.HasObservations)
+                Unlabelled.Collect(writer);
 
             foreach (var labelledMetric in LabelledMetrics)
-                labelledMetric.Value.Collect(writer);
+            {
+                if(!Configuration.SuppressEmptySamples || labelledMetric.Value.HasObservations)
+                    labelledMetric.Value.Collect(writer);
+            }
 
             writer.EndMetric();
         }

--- a/src/Prometheus.Client/Histogram.cs
+++ b/src/Prometheus.Client/Histogram.cs
@@ -112,8 +112,8 @@ namespace Prometheus.Client
         {
             private static readonly double[] _defaultBuckets = { .005, .01, .025, .05, .075, .1, .25, .5, .75, 1, 2.5, 5, 7.5, 10 };
 
-            public HistogramConfiguration(string name, string help, bool includeTimestamp, IReadOnlyList<string> labels, IReadOnlyList<double> buckets)
-                : base(name, help, includeTimestamp, labels)
+            public HistogramConfiguration(string name, string help, bool includeTimestamp, bool suppressEmptySamples, IReadOnlyList<string> labels, IReadOnlyList<double> buckets)
+                : base(name, help, includeTimestamp, suppressEmptySamples, labels)
             {
                 Buckets = buckets ?? _defaultBuckets;
 

--- a/src/Prometheus.Client/Labelled.cs
+++ b/src/Prometheus.Client/Labelled.cs
@@ -12,6 +12,7 @@ namespace Prometheus.Client
     {
         private LabelValues _labelValues;
         private long _timestamp;
+        private long _hasObservation = 0;
         protected TConfig Configuration;
 
         protected IReadOnlyList<KeyValuePair<string, string>> Labels => _labelValues.Labels;
@@ -27,6 +28,8 @@ namespace Prometheus.Client
             }
         }
 
+        public bool HasObservations => Interlocked.Read(ref _hasObservation) != 0;
+
         protected internal virtual void Init(LabelValues labelValues, TConfig configuration)
         {
             _labelValues = labelValues;
@@ -37,6 +40,8 @@ namespace Prometheus.Client
 
         protected void TimestampIfRequired(long? timestamp = null)
         {
+            Interlocked.Exchange(ref _hasObservation, 1);
+
             if (!Configuration.IncludeTimestamp)
                 return;
 

--- a/src/Prometheus.Client/MetricConfiguration.cs
+++ b/src/Prometheus.Client/MetricConfiguration.cs
@@ -10,11 +10,12 @@ namespace Prometheus.Client
         private static readonly Regex _metricNameLabelRegex = new Regex("^[a-zA-Z_:][a-zA-Z0-9_:]*$", RegexOptions.Compiled);
         private static readonly Regex _reservedLabelRegex = new Regex("^__.*$", RegexOptions.Compiled);
 
-        public MetricConfiguration(string name, string help, bool includeTimestamp, IReadOnlyList<string> labels)
+        public MetricConfiguration(string name, string help, bool includeTimestamp, bool suppressEmptySamples, IReadOnlyList<string> labels)
             : base(name)
         {
             Help = help;
             IncludeTimestamp = includeTimestamp;
+            SuppressEmptySamples = suppressEmptySamples;
             LabelNames = labels ?? Array.Empty<string>();
 
             if (!_metricNameLabelRegex.IsMatch(Name))
@@ -33,6 +34,8 @@ namespace Prometheus.Client
         public string Help { get; }
 
         public bool IncludeTimestamp { get; }
+
+        public bool SuppressEmptySamples { get; }
 
         public IReadOnlyList<string> LabelNames { get; }
     }

--- a/src/Prometheus.Client/MetricFactory.cs
+++ b/src/Prometheus.Client/MetricFactory.cs
@@ -35,10 +35,23 @@ namespace Prometheus.Client
         /// <param name="labelNames">Array of label names.</param>
         public Counter CreateCounter(string name, string help, bool includeTimestamp, params string[] labelNames)
         {
+            return CreateCounter(name, help, includeTimestamp, true, labelNames);
+        }
+
+        /// <summary>
+        ///     Create  Counter.
+        /// </summary>
+        /// <param name="name">Name.</param>
+        /// <param name="help">Help text.</param>
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="suppressEmptySamples">Define if empty samples should be included into scrape output</param>
+        /// <param name="labelNames">Array of label names.</param>
+        public Counter CreateCounter(string name, string help, bool includeTimestamp, bool suppressEmptySamples, params string[] labelNames)
+        {
             var metric = TryGetByName<Counter>(name);
             if (metric == null)
             {
-                var configuration = new MetricConfiguration(name, help, includeTimestamp, labelNames);
+                var configuration = new MetricConfiguration(name, help, includeTimestamp, suppressEmptySamples, labelNames);
                 metric = _registry.GetOrAdd(configuration, config => new Counter(config));
             }
 
@@ -66,10 +79,23 @@ namespace Prometheus.Client
         /// <param name="labelNames">Array of label names.</param>
         public CounterInt64 CreateCounterInt64(string name, string help, bool includeTimestamp, params string[] labelNames)
         {
+            return CreateCounterInt64(name, help, includeTimestamp, true, labelNames);
+        }
+
+        /// <summary>
+        ///     Create int-based counter.
+        /// </summary>
+        /// <param name="name">Name.</param>
+        /// <param name="help">Help text.</param>
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="suppressEmptySamples">Define if empty samples should be included into scrape output</param>
+        /// <param name="labelNames">Array of label names.</param>
+        public CounterInt64 CreateCounterInt64(string name, string help, bool includeTimestamp, bool suppressEmptySamples, params string[] labelNames)
+        {
             var metric = TryGetByName<CounterInt64>(name);
             if (metric == null)
             {
-                var configuration = new MetricConfiguration(name, help, includeTimestamp, labelNames);
+                var configuration = new MetricConfiguration(name, help, includeTimestamp, suppressEmptySamples, labelNames);
                 metric = _registry.GetOrAdd(configuration, config => new CounterInt64(config));
             }
 
@@ -97,10 +123,23 @@ namespace Prometheus.Client
         /// <param name="labelNames">Array of label names.</param>
         public Gauge CreateGauge(string name, string help, bool includeTimestamp, params string[] labelNames)
         {
+            return CreateGauge(name, help, includeTimestamp, true, labelNames);
+        }
+
+        /// <summary>
+        ///     Create Gauge
+        /// </summary>
+        /// <param name="name">Name.</param>
+        /// <param name="help">Help text.</param>
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="suppressEmptySamples">Define if empty samples should be included into scrape output</param>
+        /// <param name="labelNames">Array of label names.</param>
+        public Gauge CreateGauge(string name, string help, bool includeTimestamp, bool suppressEmptySamples, params string[] labelNames)
+        {
             var metric = TryGetByName<Gauge>(name);
             if (metric == null)
             {
-                var configuration = new MetricConfiguration(name, help, includeTimestamp, labelNames);
+                var configuration = new MetricConfiguration(name, help, includeTimestamp, suppressEmptySamples, labelNames);
                 metric = _registry.GetOrAdd(configuration, config => new Gauge(config));
             }
 
@@ -128,10 +167,23 @@ namespace Prometheus.Client
         /// <param name="labelNames">Array of label names.</param>
         public Untyped CreateUntyped(string name, string help, bool includeTimestamp, params string[] labelNames)
         {
+            return CreateUntyped(name, help, includeTimestamp, true, labelNames);
+        }
+
+        /// <summary>
+        ///     Create Untyped.
+        /// </summary>
+        /// <param name="name">Name.</param>
+        /// <param name="help">Help text.</param>
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="suppressEmptySamples">Define if empty samples should be included into scrape output</param>
+        /// <param name="labelNames">Array of label names.</param>
+        public Untyped CreateUntyped(string name, string help, bool includeTimestamp, bool suppressEmptySamples, params string[] labelNames)
+        {
             var metric = TryGetByName<Untyped>(name);
             if (metric == null)
             {
-                var configuration = new MetricConfiguration(name, help, includeTimestamp, labelNames);
+                var configuration = new MetricConfiguration(name, help, includeTimestamp, suppressEmptySamples, labelNames);
                 metric = _registry.GetOrAdd(configuration, config => new Untyped(config));
             }
 
@@ -198,10 +250,36 @@ namespace Prometheus.Client
             int? ageBuckets,
             int? bufCap)
         {
+            return CreateSummary(name, help, includeTimestamp, true, labelNames, objectives, maxAge, ageBuckets, bufCap);
+        }
+
+        /// <summary>
+        ///     Create Summary
+        /// </summary>
+        /// <param name="name">Name.</param>
+        /// <param name="help">Help text.</param>
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="suppressEmptySamples">Define if empty samples should be included into scrape output</param>
+        /// <param name="labelNames">Array of label names.</param>
+        /// <param name="objectives">.</param>
+        /// <param name="maxAge"></param>
+        /// <param name="ageBuckets"></param>
+        /// <param name="bufCap"></param>
+        public Summary CreateSummary(
+            string name,
+            string help,
+            bool includeTimestamp,
+            bool suppressEmptySamples,
+            string[] labelNames,
+            IReadOnlyList<QuantileEpsilonPair> objectives,
+            TimeSpan? maxAge,
+            int? ageBuckets,
+            int? bufCap)
+        {
             var metric = TryGetByName<Summary>(name);
             if (metric == null)
             {
-                var configuration = new Summary.SummaryConfiguration(name, help, includeTimestamp, labelNames, objectives, maxAge, ageBuckets, bufCap);
+                var configuration = new Summary.SummaryConfiguration(name, help, includeTimestamp, suppressEmptySamples, labelNames, objectives, maxAge, ageBuckets, bufCap);
                 metric = _registry.GetOrAdd(configuration, config => new Summary(config));
             }
 
@@ -254,10 +332,24 @@ namespace Prometheus.Client
         /// <param name="labelNames">Array of label names.</param>
         public Histogram CreateHistogram(string name, string help, bool includeTimestamp, double[] buckets, params string[] labelNames)
         {
+            return CreateHistogram(name, help, includeTimestamp, true, buckets, labelNames);
+        }
+
+        /// <summary>
+        ///     Create Histogram.
+        /// </summary>
+        /// <param name="name">Name.</param>
+        /// <param name="help">Help text.</param>
+        /// <param name="includeTimestamp">Include unix timestamp for metric.</param>
+        /// <param name="suppressEmptySamples">Define if empty samples should be included into scrape output</param>
+        /// <param name="buckets">Buckets.</param>
+        /// <param name="labelNames">Array of label names.</param>
+        public Histogram CreateHistogram(string name, string help, bool includeTimestamp, bool suppressEmptySamples, double[] buckets, params string[] labelNames)
+        {
             var metric = TryGetByName<Histogram>(name);
             if (metric == null)
             {
-                var configuration = new Histogram.HistogramConfiguration(name, help, includeTimestamp, labelNames, buckets);
+                var configuration = new Histogram.HistogramConfiguration(name, help, includeTimestamp, suppressEmptySamples, labelNames, buckets);
                 metric = _registry.GetOrAdd(configuration, config => new Histogram(config));
             }
 

--- a/src/Prometheus.Client/Summary.cs
+++ b/src/Prometheus.Client/Summary.cs
@@ -244,12 +244,13 @@ namespace Prometheus.Client
                 string name,
                 string help,
                 bool includeTimestamp,
+                bool suppressEmptySamples,
                 IReadOnlyList<string> labelNames,
                 IReadOnlyList<QuantileEpsilonPair> objectives = null,
                 TimeSpan? maxAge = null,
                 int? ageBuckets = null,
                 int? bufCap = null)
-            : base(name, help, includeTimestamp, labelNames)
+            : base(name, help, includeTimestamp, suppressEmptySamples, labelNames)
             {
                 Objectives = objectives;
                 if (Objectives == null || Objectives.Count == 0)

--- a/tests/Prometheus.Client.Tests/Prometheus.Client.Tests.csproj
+++ b/tests/Prometheus.Client.Tests/Prometheus.Client.Tests.csproj
@@ -5,11 +5,19 @@
     <AssemblyOriginatorKeyFile>../../Prometheus.Client.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="Resources\CounterTests_SuppressEmpty.txt" />
+    <None Remove="Resources\GaugeTests_SuppressEmpty.txt" />
+    <None Remove="Resources\HistogramTests_SuppressEmpty.txt" />
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="Resources\CollectorRegistryTests_Collection.txt" />
+    <EmbeddedResource Include="Resources\CounterTests_SuppressEmpty.txt" />
     <EmbeddedResource Include="Resources\CounterTests_Collection.txt" />
     <EmbeddedResource Include="Resources\CounterTests_Empty.txt" />
+    <EmbeddedResource Include="Resources\GaugeTests_SuppressEmpty.txt" />
     <EmbeddedResource Include="Resources\GaugeTests_Collection.txt" />
     <EmbeddedResource Include="Resources\GaugeTests_Empty.txt" />
+    <EmbeddedResource Include="Resources\HistogramTests_SuppressEmpty.txt" />
     <EmbeddedResource Include="Resources\HistogramTests_Collection.txt" />
     <EmbeddedResource Include="Resources\HistogramTests_Empty.txt" />
     <EmbeddedResource Include="Resources\UntypedTests_Collection.txt" />

--- a/tests/Prometheus.Client.Tests/Resources/CounterTests_SuppressEmpty.txt
+++ b/tests/Prometheus.Client.Tests/Resources/CounterTests_SuppressEmpty.txt
@@ -1,0 +1,3 @@
+# HELP test with help text
+# TYPE test counter
+test{category="some"} 5

--- a/tests/Prometheus.Client.Tests/Resources/GaugeTests_SuppressEmpty.txt
+++ b/tests/Prometheus.Client.Tests/Resources/GaugeTests_SuppressEmpty.txt
@@ -1,0 +1,3 @@
+# HELP test with help text
+# TYPE test gauge
+test{category="some"} 5

--- a/tests/Prometheus.Client.Tests/Resources/HistogramTests_SuppressEmpty.txt
+++ b/tests/Prometheus.Client.Tests/Resources/HistogramTests_SuppressEmpty.txt
@@ -1,0 +1,9 @@
+# HELP hist1 help
+# TYPE hist1 histogram
+hist1_bucket{type="a",le="-5"} 1
+hist1_bucket{type="a",le="0"} 3
+hist1_bucket{type="a",le="5"} 5
+hist1_bucket{type="a",le="10"} 6
+hist1_bucket{type="a",le="+Inf"} 7
+hist1_sum{type="a"} 6.5
+hist1_count{type="a"} 7

--- a/tests/Prometheus.Client.Tests/SummaryTests.cs
+++ b/tests/Prometheus.Client.Tests/SummaryTests.cs
@@ -21,7 +21,7 @@ namespace Prometheus.Client.Tests
             int concLevel = (n % 5) + 1;
             int total = mutations * concLevel;
 
-            var sum = new Summary(new Summary.SummaryConfiguration("test_summary", "helpless", false, new string[0]));
+            var sum = new Summary(new Summary.SummaryConfiguration("test_summary", "helpless", false, false, new string[0]));
             var allVars = new double[total];
             double sampleSum = 0;
             var tasks = new List<Task>();
@@ -139,7 +139,7 @@ namespace Prometheus.Client.Tests
         {
             var baseTime = new DateTime(2015, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-            var summaryConfig = new Summary.SummaryConfiguration("test_summary", "helpless", false, new string[0],
+            var summaryConfig = new Summary.SummaryConfiguration("test_summary", "helpless", false, false, new string[0],
                 new List<QuantileEpsilonPair> { new QuantileEpsilonPair(0.1d, 0.001d) }, TimeSpan.FromSeconds(100), 10);
             var child = new Summary.LabelledSummary();
             child.Init(LabelValues.Empty, summaryConfig, baseTime);

--- a/tests/Prometheus.Client.Tests/UntypedTests.cs
+++ b/tests/Prometheus.Client.Tests/UntypedTests.cs
@@ -112,7 +112,7 @@ namespace Prometheus.Client.Tests
             var registry = new CollectorRegistry();
             var factory = new MetricFactory(registry);
 
-            var untyped = factory.CreateUntyped("test", "with help text", "category");
+            var untyped = factory.CreateUntyped("test", "with help text", false, false, "category");
             
             string formattedText = null;
 


### PR DESCRIPTION
Added SuppressEmptySamples configuration value to all metrics to omit metrics without observation from scrape, default to true to mimic v2 output